### PR TITLE
Updated array field view with optional tooltips and optional remove button/disable button

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -313,5 +313,9 @@ Template.autoForm.events({
     var ss = formData[formId].ss;
 
     arrayTracker.addOneToField(formId, name, ss, minCount, maxCount);
+  },
+  'mouseenter .tooltip-wrapper' : function autoFormMouseenterAddItem(event, template) {
+    //Tried this in rendered event on template but it doesnt trigger when the temlate changes and the jquery events un-hook
+    $(event.currentTarget).tooltip({'placement': 'bottom'});
   }
 });

--- a/autoform-events.js
+++ b/autoform-events.js
@@ -292,14 +292,22 @@ Template.autoForm.events({
     arrayTracker.removeFromFieldAtIndex(formId, name, index, ss, minCount, maxCount);
   },
   'click .autoform-add-item': function autoFormClickAddItem(event, template) {
+    var self = this;
+    
     event.preventDefault();
 
-    // We pull from data attributes because the button could be manually
+    // We try to pull from data attributes because the button could be manually
     // added anywhere, so we don't know the data context.
     var btn = $(event.currentTarget);
     var name = btn.attr("data-autoform-field");
     var minCount = btn.attr("data-autoform-minCount"); // optional, overrides schema
     var maxCount = btn.attr("data-autoform-maxCount"); // optional, overrides schema
+    if (!name){
+        //if no attributes it should be in an afEachArrayItem block
+        name = self.arrayFieldName;
+        minCount = self.minCount; // optional, overrides schema
+        maxCount = self.maxCount; // optional, overrides schema
+    }
     var data = template.data;
     var formId = data && data.id || defaultFormId;
     var ss = formData[formId].ss;

--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -83,21 +83,6 @@ UI.registerHelper('afArrayFieldIsEmpty', function autoFormArrayFieldIsEmpty(opti
 });
 
 /*
- * afTextFromAttsOrDefault
- */
-UI.registerHelper('afTextFromAttsOrDefault', function autoFormTextFromAttsOrDefault(options) {
-  if(!options.hash) 
-    throw new Error("afTextFromAttsOrDefault should be used passing 'fromAtts' and 'default' strings");
-  if(options.hash.fromAtts === false) 
-    return '';
-  if((typeof options.hash.fromAtts) === 'string')
-    return options.hash.fromAtts;
-  if((typeof options.hash.default) !== 'string')
-    throw new Error("afTextFromAttsOrDefault 'default' should be a string.");
-  return options.hash.default;
-});
-
-/*
  * afFieldValueContains
  */
 UI.registerHelper('afFieldValueContains', function autoFormFieldValueContains(options) {

--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -74,6 +74,46 @@ UI.registerHelper('afArrayFieldIsLastVisible', function autoFormArrayFieldIsLast
   return arrayTracker.isLastFieldlVisible(context.formId, context.arrayFieldName, context.index);
 });
 
+
+/*
+ * afArrayFieldShowAdd
+ */
+UI.registerHelper('afArrayFieldShowAdd', function autoFormArrayFieldShowAdd(type) {
+  var context = this;
+  var last =  arrayTracker.isLastFieldlVisible(context.formId, context.arrayFieldName, context.index);
+  if (!last) return (type == 'btn') ? 'invisible' : '';
+  
+  var range = arrayTracker.getMinMax(formData[context.formId].ss, context.arrayFieldName, context.minCount, context.maxCount);
+  var visibleCount = arrayTracker.getVisibleCount(context.formId, context.arrayFieldName);
+  if (visibleCount < range.maxCount){
+    return '';
+  }else{
+    return (type == 'btn') ? 'disabled' : 'Max Limit Reached';
+  }
+});
+
+/*
+ * afArrayFieldShowRemove
+ */
+UI.registerHelper('afArrayFieldShowRemove', function autoFormArrayFieldShowRemove(type) {
+  var context = this;
+  var range = arrayTracker.getMinMax(formData[context.formId].ss, context.arrayFieldName, context.minCount, context.maxCount);
+  var visibleCount = arrayTracker.getVisibleCount(context.formId, context.arrayFieldName);
+  if (visibleCount > range.minCount){
+    return '';
+  }else{
+    return (type == 'btn') ? 'disabled' : 'Min Limit Reached';
+  }
+});
+
+/*
+ * afIsEmpty
+ */
+UI.registerHelper('afArrayFieldIsEmpty', function autoFormArrayFieldIsEmpty(options) {
+  options = parseOptions(options, this, 'afIsEmpty');
+  return arrayTracker.getVisibleCount(options.formId, options.name) === 0;
+});
+
 /*
  * afFieldValueContains
  */

--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -74,44 +74,27 @@ UI.registerHelper('afArrayFieldIsLastVisible', function autoFormArrayFieldIsLast
   return arrayTracker.isLastFieldlVisible(context.formId, context.arrayFieldName, context.index);
 });
 
-
 /*
- * afArrayFieldShowAdd
- */
-UI.registerHelper('afArrayFieldShowAdd', function autoFormArrayFieldShowAdd(type) {
-  var context = this;
-  var last =  arrayTracker.isLastFieldlVisible(context.formId, context.arrayFieldName, context.index);
-  if (!last) return (type == 'btn') ? 'invisible' : '';
-  
-  var range = arrayTracker.getMinMax(formData[context.formId].ss, context.arrayFieldName, context.minCount, context.maxCount);
-  var visibleCount = arrayTracker.getVisibleCount(context.formId, context.arrayFieldName);
-  if (visibleCount < range.maxCount){
-    return '';
-  }else{
-    return (type == 'btn') ? 'disabled' : 'Max Limit Reached';
-  }
-});
-
-/*
- * afArrayFieldShowRemove
- */
-UI.registerHelper('afArrayFieldShowRemove', function autoFormArrayFieldShowRemove(type) {
-  var context = this;
-  var range = arrayTracker.getMinMax(formData[context.formId].ss, context.arrayFieldName, context.minCount, context.maxCount);
-  var visibleCount = arrayTracker.getVisibleCount(context.formId, context.arrayFieldName);
-  if (visibleCount > range.minCount){
-    return '';
-  }else{
-    return (type == 'btn') ? 'disabled' : 'Min Limit Reached';
-  }
-});
-
-/*
- * afIsEmpty
+ * afArrayFieldIsEmpty
  */
 UI.registerHelper('afArrayFieldIsEmpty', function autoFormArrayFieldIsEmpty(options) {
   options = parseOptions(options, this, 'afIsEmpty');
   return arrayTracker.getVisibleCount(options.formId, options.name) === 0;
+});
+
+/*
+ * afTextFromAttsOrDefault
+ */
+UI.registerHelper('afTextFromAttsOrDefault', function autoFormTextFromAttsOrDefault(options) {
+  if(!options.hash) 
+    throw new Error("afTextFromAttsOrDefault should be used passing 'fromAtts' and 'default' strings");
+  if(options.hash.fromAtts === false) 
+    return '';
+  if((typeof options.hash.fromAtts) === 'string')
+    return options.hash.fromAtts;
+  if((typeof options.hash.default) !== 'string')
+    throw new Error("afTextFromAttsOrDefault 'default' should be a string.");
+  return options.hash.default;
 });
 
 /*

--- a/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
+++ b/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
@@ -73,10 +73,10 @@
           {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
             <li class="list-group-item autoform-array-item">
               <div class="media">
-                {{> afArrayFieldAddButton}}
-                {{> afArrayFieldRemoveButton}}
+                {{> afArrayFieldAddButton_bootstrap3}}
+                {{> afArrayFieldRemoveButton_bootstrap3}}
                 <div class="media-body">
-                  {{> afQuickField name=this.name label=false}}
+                  {{> afQuickField name=this.name label=false options="auto" fields=../atts.fields omitFields=../atts.omitFields}}
                 </div>
               </div>
             </li>
@@ -84,17 +84,5 @@
         </ul>
       </div>
     </div>
-  </div>
-</template>
-
-<template name="afArrayFieldAddButton">
-  <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afArrayFieldShowAdd 'tt'}}">
-    <button class="btn btn-primary autoform-add-item {{afArrayFieldShowAdd 'btn'}}"><span class="glyphicon glyphicon-plus"></span></button>
-  </div>
-</template>
-
-<template name="afArrayFieldRemoveButton">
-  <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afArrayFieldShowRemove 'tt'}}">
-    <button class="btn btn-primary autoform-remove-item {{afArrayFieldShowRemove 'btn'}}"><span class="glyphicon glyphicon-minus"></span></button>
   </div>
 </template>

--- a/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
+++ b/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
@@ -65,25 +65,36 @@
         </div>
         {{/if}}
         <ul class="list-group">
-          {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
-          <li class="list-group-item autoform-array-item">
-            <div class="media">
-              {{#if afArrayFieldHasMoreThanMinimum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
-              <button class="btn btn-primary autoform-remove-item pull-left"><span class="glyphicon glyphicon-minus"></span></button>
-              {{/if}}
-              <div class="media-body">
-                {{> afQuickField name=this.name label=false}}
-              </div>
-            </div>
-          </li>
-          {{/afEachArrayItem}}
-          {{#if afArrayFieldHasLessThanMaximum name=this.atts.name autoform=this.autoform minCount=this.atts.minCount maxCount=this.atts.maxCount}}
-          <li class="list-group-item">
-            <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
-          </li>
+          {{#if afArrayFieldIsEmpty name=this.atts.name}}
+            <li class="list-group-item autoform-array-item">
+              <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
+            </li>
           {{/if}}
+          {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
+            <li class="list-group-item autoform-array-item">
+              <div class="media">
+                {{> afArrayFieldAddButton}}
+                {{> afArrayFieldRemoveButton}}
+                <div class="media-body">
+                  {{> afQuickField name=this.name label=false}}
+                </div>
+              </div>
+            </li>
+          {{/afEachArrayItem}}
         </ul>
       </div>
     </div>
+  </div>
+</template>
+
+<template name="afArrayFieldAddButton">
+  <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afArrayFieldShowAdd 'tt'}}">
+    <button class="btn btn-primary autoform-add-item {{afArrayFieldShowAdd 'btn'}}"><span class="glyphicon glyphicon-plus"></span></button>
+  </div>
+</template>
+
+<template name="afArrayFieldRemoveButton">
+  <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afArrayFieldShowRemove 'tt'}}">
+    <button class="btn btn-primary autoform-remove-item {{afArrayFieldShowRemove 'btn'}}"><span class="glyphicon glyphicon-minus"></span></button>
   </div>
 </template>

--- a/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
+++ b/templates/bootstrap3-horizontal/bootstrap3-horizontal.html
@@ -66,15 +66,15 @@
         {{/if}}
         <ul class="list-group">
           {{#if afArrayFieldIsEmpty name=this.atts.name}}
-            <li class="list-group-item autoform-array-item">
+            <li class="list-group-item">
               <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
             </li>
           {{/if}}
           {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
             <li class="list-group-item autoform-array-item">
               <div class="media">
-                {{> afArrayFieldAddButton_bootstrap3}}
                 {{> afArrayFieldRemoveButton_bootstrap3}}
+                {{> afArrayFieldAddButton_bootstrap3}}
                 <div class="media-body">
                   {{> afQuickField name=this.name label=false options="auto" fields=../atts.fields omitFields=../atts.omitFields}}
                 </div>

--- a/templates/bootstrap3-horizontal/bootstrap3-horizontal.js
+++ b/templates/bootstrap3-horizontal/bootstrap3-horizontal.js
@@ -96,3 +96,11 @@ Template["afArrayField_bootstrap3-horizontal"].afFieldLabelAtts = function () {
     "name": atts.name
   };
 };
+
+Template["afArrayFieldAddButton"].rendered = function() {
+   $('.tooltip-wrapper').tooltip({'placement': 'bottom'});
+};
+
+Template["afArrayFieldRemoveButton"].rendered = function() {
+   $('.tooltip-wrapper').tooltip({'placement': 'bottom'});
+};

--- a/templates/bootstrap3-horizontal/bootstrap3-horizontal.js
+++ b/templates/bootstrap3-horizontal/bootstrap3-horizontal.js
@@ -96,11 +96,3 @@ Template["afArrayField_bootstrap3-horizontal"].afFieldLabelAtts = function () {
     "name": atts.name
   };
 };
-
-Template["afArrayFieldAddButton"].rendered = function() {
-   $('.tooltip-wrapper').tooltip({'placement': 'bottom'});
-};
-
-Template["afArrayFieldRemoveButton"].rendered = function() {
-   $('.tooltip-wrapper').tooltip({'placement': 'bottom'});
-};

--- a/templates/bootstrap3/bootstrap3.html
+++ b/templates/bootstrap3/bootstrap3.html
@@ -138,7 +138,7 @@
         <div class="media">
           {{> afArrayFieldRemoveButton_bootstrap3}}
           {{> afArrayFieldAddButton_bootstrap3}}
-          <div class="media-body" style="overflow: hidden;">
+          <div class="media-body">
             {{> afQuickField name=this.name label=false options="auto" fields=../atts.fields omitFields=../atts.omitFields}}
           </div>
         </div>

--- a/templates/bootstrap3/bootstrap3.html
+++ b/templates/bootstrap3/bootstrap3.html
@@ -129,16 +129,16 @@
     {{/if}}
     <ul class="list-group">
       {{#if afArrayFieldIsEmpty name=this.atts.name}}
-        <li class="list-group-item autoform-array-item">
+        <li class="list-group-item">
           <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
         </li>
       {{/if}}
       {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
       <li class="list-group-item autoform-array-item">
         <div class="media">
-          {{> afArrayFieldAddButton_bootstrap3}}
           {{> afArrayFieldRemoveButton_bootstrap3}}
-          <div class="media-body">
+          {{> afArrayFieldAddButton_bootstrap3}}
+          <div class="media-body" style="overflow: hidden;">
             {{> afQuickField name=this.name label=false options="auto" fields=../atts.fields omitFields=../atts.omitFields}}
           </div>
         </div>
@@ -153,16 +153,12 @@
     {{#if afArrayFieldHasLessThanMaximum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
         <button class="btn btn-primary autoform-add-item pull-left"><span class="glyphicon glyphicon-plus"></span></button>
     {{else}}
-      {{#if ../atts.removeButtons}}
-          <button class="btn btn-primary autoform-add-item invisible pull-left"><span class="glyphicon glyphicon-plus"></span></button>
-      {{else}}
+      {{#unless ../atts.removeButtons}}
         <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afTextFromAttsOrDefault fromAtts=../atts.maxTooltipText default='Max Count Reached'}}">
           <button class="btn btn-primary autoform-add-item disabled"><span class="glyphicon glyphicon-plus"></span></button>
         </div>
-      {{/if}}
+      {{/unless}}
     {{/if}}
-  {{else}}
-      <button class="btn btn-primary autoform-add-item invisible pull-left"><span class="glyphicon glyphicon-plus"></span></button>
   {{/if}}
 </template>
 
@@ -170,12 +166,10 @@
   {{#if afArrayFieldHasMoreThanMinimum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
         <button class="btn btn-primary autoform-remove-item pull-left"><span class="glyphicon glyphicon-minus"></span></button>
   {{else}}
-    {{#if ../atts.removeButtons}}
-        <button class="btn btn-primary autoform-remove-item invisible pull-left"><span class="glyphicon glyphicon-minus"></span></button>
-    {{else}}
+    {{#unless ../atts.removeButtons}}
       <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afTextFromAttsOrDefault fromAtts=../atts.minTooltipText default='Min Count Reached'}}">
         <button class="btn btn-primary autoform-remove-item disabled"><span class="glyphicon glyphicon-minus"></span></button>
       </div>
-    {{/if}}
+    {{/unless}}
   {{/if}}
 </template>

--- a/templates/bootstrap3/bootstrap3.html
+++ b/templates/bootstrap3/bootstrap3.html
@@ -128,23 +128,54 @@
     </div>
     {{/if}}
     <ul class="list-group">
+      {{#if afArrayFieldIsEmpty name=this.atts.name}}
+        <li class="list-group-item autoform-array-item">
+          <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
+        </li>
+      {{/if}}
       {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
       <li class="list-group-item autoform-array-item">
         <div class="media">
-          {{#if afArrayFieldHasMoreThanMinimum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
-          <button class="btn btn-primary autoform-remove-item pull-left"><span class="glyphicon glyphicon-minus"></span></button>
-          {{/if}}
+          {{> afArrayFieldAddButton_bootstrap3}}
+          {{> afArrayFieldRemoveButton_bootstrap3}}
           <div class="media-body">
             {{> afQuickField name=this.name label=false options="auto" fields=../atts.fields omitFields=../atts.omitFields}}
           </div>
         </div>
       </li>
       {{/afEachArrayItem}}
-      {{#if afArrayFieldHasLessThanMaximum name=this.atts.name autoform=this.autoform minCount=this.atts.minCount maxCount=this.atts.maxCount}}
-      <li class="list-group-item">
-        <button class="btn btn-primary autoform-add-item" data-autoform-field="{{this.atts.name}}" data-autoform-minCount="{{this.atts.minCount}}" data-autoform-maxCount="{{this.atts.maxCount}}"><span class="glyphicon glyphicon-plus"></span></button>
-      </li>
-      {{/if}}
     </ul>
   </div>
+</template>
+
+<template name="afArrayFieldAddButton_bootstrap3">
+  {{#if afArrayFieldIsLastVisible}}
+    {{#if afArrayFieldHasLessThanMaximum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
+        <button class="btn btn-primary autoform-add-item pull-left"><span class="glyphicon glyphicon-plus"></span></button>
+    {{else}}
+      {{#if ../atts.removeButtons}}
+          <button class="btn btn-primary autoform-add-item invisible pull-left"><span class="glyphicon glyphicon-plus"></span></button>
+      {{else}}
+        <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afTextFromAttsOrDefault fromAtts=../atts.maxTooltipText default='Max Count Reached'}}">
+          <button class="btn btn-primary autoform-add-item disabled"><span class="glyphicon glyphicon-plus"></span></button>
+        </div>
+      {{/if}}
+    {{/if}}
+  {{else}}
+      <button class="btn btn-primary autoform-add-item invisible pull-left"><span class="glyphicon glyphicon-plus"></span></button>
+  {{/if}}
+</template>
+
+<template name="afArrayFieldRemoveButton_bootstrap3">
+  {{#if afArrayFieldHasMoreThanMinimum name=../atts.name autoform=../autoform minCount=../atts.minCount maxCount=../atts.maxCount}}
+        <button class="btn btn-primary autoform-remove-item pull-left"><span class="glyphicon glyphicon-minus"></span></button>
+  {{else}}
+    {{#if ../atts.removeButtons}}
+        <button class="btn btn-primary autoform-remove-item invisible pull-left"><span class="glyphicon glyphicon-minus"></span></button>
+    {{else}}
+      <div class="tooltip-wrapper pull-left" data-toggle="tooltip" data-title="{{afTextFromAttsOrDefault fromAtts=../atts.minTooltipText default='Min Count Reached'}}">
+        <button class="btn btn-primary autoform-remove-item disabled"><span class="glyphicon glyphicon-minus"></span></button>
+      </div>
+    {{/if}}
+  {{/if}}
 </template>

--- a/templates/bootstrap3/bootstrap3.js
+++ b/templates/bootstrap3/bootstrap3.js
@@ -79,3 +79,25 @@ Template["afSelect_bootstrap3"].optionAtts = function () {
   }
   return atts;
 };
+
+/*
+ * afTextFromAttsOrDefault
+ */
+function autoFormTextFromAttsOrDefault(options) {
+  if(!options.hash) 
+    throw new Error("afTextFromAttsOrDefault should be used passing 'fromAtts' and 'default' strings");
+  if(options.hash.fromAtts === false) 
+    return '';
+  if((typeof options.hash.fromAtts) === 'string')
+    return options.hash.fromAtts;
+  if((typeof options.hash.default) !== 'string')
+    throw new Error("afTextFromAttsOrDefault 'default' should be a string.");
+  return options.hash.default;
+};
+
+Template["afArrayFieldAddButton_bootstrap3"].helpers({
+  afTextFromAttsOrDefault: autoFormTextFromAttsOrDefault
+});
+Template["afArrayFieldRemoveButton_bootstrap3"].helpers({
+  afTextFromAttsOrDefault: autoFormTextFromAttsOrDefault
+});

--- a/templates/bootstrap3/bootstrap3.js
+++ b/templates/bootstrap3/bootstrap3.js
@@ -70,7 +70,7 @@ Template["afRadioGroup_bootstrap3"].atts = function () {
 };
 
 Template["afSelect_bootstrap3"].optionAtts = function () {
-  var item = this
+  var item = this;
   var atts = {
     value: item.value
   };


### PR DESCRIPTION
I have adjusted my modified arrayfield implementation, it is now both in the normal bootstrap3 template and the horizontal one.
I have added support for optional attributes on the `afArrayField` as follows:
`minTooltipText` & `maxTooltipText`
If undefined the default text will be used for the tooltips ('Min Count Reached' & 'Max Count Reached')
If defined with a value of false no tooltip will be shown.
If defined with a string value the string will be used for the tooltip text
`removeButtons`
If defined with a value of true the buttons will be removed
If undefined or false the buttons will be disabled when maxCount is reached or minCount is reached
