### PR TITLE
afFieldValueContains: -values, +value as function

### DIFF
--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -78,7 +78,12 @@ regHelper('afFieldValueContains', function autoFormFieldValueContains(options) {
   options = parseOptions(options, 'afFieldValueContains');
 
   var currentValue = AutoForm.getFieldValue(options.formId, options.name);
-  return _.isArray(currentValue) && (_.contains(currentValue, options.value) || options.values && _.intersection(currentValue, options.values.split(",")));
+  
+  if (typeof options.value === "function") {
+    return options.value(currentValue);  
+  } 
+  
+  return _.isArray(currentValue) && _.contains(currentValue, options.value);
 });
 
 /*


### PR DESCRIPTION
proposed "values" - it is bad way, you can see my attempts [here](https://github.com/aldeed/meteor-autoform/pull/515)

very simple and true solution:

```
<template="myForm">
...
  {{#if afFieldValueContains name="myField" value=conditions}}
...
</template>
```

```
Template.myForm.helpers
  "conditions": ->
    (currentValue) ->
      currentValue # you can place your conditions here 
```
