### PR TITLE
YYYY-MM-DD ISO format is interpreted as local time in ES2015

### DIFF
--- a/inputTypes/date/date.js
+++ b/inputTypes/date/date.js
@@ -7,9 +7,10 @@ AutoForm.addInputType("date", {
   valueOut: function () {
     var val = this.val();
     if (AutoForm.Utility.isValidDateString(val)) {
-      //Date constructor will interpret val as UTC and create
-      //date at mignight in the morning of val date in UTC time zone
-      return new Date(val);
+      //Create date at mignight in the morning of val date in UTC time zone
+      var vals = val.split('-');
+      --vals[1];
+      return new Date(Date.UTC.apply(Date, vals));
     } else {
       return null;
     }


### PR DESCRIPTION
Chrome's Date.parse() YYYY-MM-DD ISO format interpretation seems to have switched to local date as defined in ES2015. This pull request uses Date.UTC to ensure we get UTC either way.

Date.parse() - Differences in assumed time zone
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
