### PR TITLE
Clean empty strings from array and resize the array accordingly

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -20,6 +20,10 @@ Utility = {
           newDoc[key] = val;
         }
       } else if (_.isArray(val)) {
+        // Make sure the empty strings are removed and the array change its length accordingly
+        if (!keepEmptyStrings) {
+          val = val.filter(Boolean);
+        }   
         val = cleanNulls(val, true, keepEmptyStrings); //recurse into non-typed arrays
         if (!_.isEmpty(val)) {
           newDoc[key] = val;


### PR DESCRIPTION
When submiting a form after removing exisiting items from array of Strings, the modifier gets array with null values in the place of the deleted strings, This fix correct it so the modifier gets array with only the remaining fields with the correct length.
Might solve the issues #1263, #1049, #1004
