### PR TITLE
omit in SimpleSchema can now be a function

### DIFF
--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -231,6 +231,10 @@ Template.registerHelper("afFieldNames", function autoFormFieldNames(options) {
       return false;
     }
 
+    if(fieldDefs.autoform && _.isFunction(fieldDefs.autoform.omit) && fieldDefs.autoform.omit(field) === true) {
+      return false;
+    }
+
     // Don't include fields with denyInsert=true when it's an insert form
     if (fieldDefs.denyInsert && form.type === "insert") {
       return false;


### PR DESCRIPTION
In SimpleSchema autoform.omit can now be a function. It is a reactive context.

The name of the field is passed as argument. This allows to find sibling or parent fields in nested objects or arrays.

```
new SimpleSchema({
  title: {
    type: String,
    autoform: {
      omit: function(fieldName){
        return true;         
      }
    }
  }
});
```
- [ ] find other / better arguments to pass
- [ ] fix wrong fieldName if field is in array and an element was removed
