### PR TITLE
Changing validation of fields wihout a group

### DIFF
--- a/components/quickForm/quickForm.js
+++ b/components/quickForm/quickForm.js
@@ -130,7 +130,7 @@ function getFieldsForGroup(groupName, schemaObj) {
  */
 function getFieldsWithNoGroup(schemaObj) {
   var fields = _.map(schemaObj, function (field, fieldName) {
-    return (fieldName.slice(-2) !== '.$') &&
+    return (fieldName.indexOf('.$') === -1) &&
       (!field.autoform || !field.autoform.group) &&
       fieldName;
   });


### PR DESCRIPTION
Scenario: Add `autoform.group` to all fields inside schema, including a field that is an array of objects. Add group just to parent field. Example:

chemicals:
  group: 2

chemicals.$.name
 // nothing

In this case quickform was not understanding that he should not consider group option in child fields, because they will be grouped according to their parents. This simple fix changes this behavior. 

Here is my schema (change collections to some values in order to test)

```
new SimpleSchema({
  packagingHouse: {
    type: String,
    optional: true,
    label: 'Empacadora',
    autoform: {
      group: 'Step 2',
      afFieldInput: {
        type: 'select',
        options: function () {
          return PackagingHouses.find({}).map(function (item) {
            return {value: item.name, label: item.name}
          });
        }
      }
    }
  },
  date: {
    type: Date,
    optional: true,
    label: 'Fecha',
    autoform: {
      group: 'Step 2'
    }
  },
  applicationDate: {
    type: Date,
    optional: true,
    label: 'Fecha de Aplicacion',
    autoform: {
      group: 'Step 2'
    }
  },
  dayOfWeek: {
    type: Number,
    optional: true,
    label: 'Día de la semana',
    autoform: {
      group: 'Step 2',
      afFieldInput: {
        disabled: true,
        value: function () {
          var date = AutoForm.getFieldValue('applicationDate');
          return moment(date).day() + 1;
        }
      }
    }
  },
  weekOfYear: {
    type: Number,
    optional: true,
    label: 'Semana del Año',
    autoform: {
      group: 'Step 2',
      afFieldInput: {
        disabled: true,
        value: function () {
          var date = AutoForm.getFieldValue('applicationDate');
          return moment(date).isoWeek();
        }
      }
    }
  },
  appliedMixture: {
    type: String,
    optional: true,
    label: 'Mezcla Aplicada',
    autoform: {
      group: 'Step 3',
    }
  },
  remainingMixture: {
    type: String,
    optional: true,
    label: 'Mezcla Sobrante',
    autoform: {
      group: 'Step 3',
    }
  },
  equipment: {
    type: [String],
    optional: true,
    allowedValues: ['Guantes', 'overol', 'botas', 'Botas de hule', 'Lentes', 'Gorro', 'Mascarilla'],
    label: 'Equipos utilizados para Aplicación',
    autoform: {
      group: 'Step 3',
      afFieldInput: {
        type: 'select-checkbox'
      }
    }
  },
  method: {
    type: String,
    optional: true,
    allowedValues: ['Aspersión', 'Empapado', 'Nebulización'],
    label: 'Método de Aplicación',
    autoform: {
      group: 'Step 3',
      afFieldInput: {
        type: 'select'
      }
    }
  },
  machineryId: {
    type: String,
    optional: true,
    label: 'Identificación de Maquinaria',
    autoform: {
      group: 'Step 3'
    }
  },
  chemicals: {
    type: [Object],
    optional: true,
    label: 'Fungicidas',
    autoform: {
      group: 'Step 4'
    }
  },
  'chemicals.$.name': {
    type: String,
    optional: true,
    label: 'Nombre Comercial',
    autoform: {
      afFieldInput: {
        type: 'select',
        options: function () {
          return Fungicides.find({status: {$ne: "Inactivo"}}).map(function (item) {
            return {value: item.name, label: item.name}
          });
        }
      }
    }
  },
  'chemicals.$.activeIngredient': {
    type: String,
    optional: true,
    label: 'Ingrediente Activo',
    autoform: {
      afFieldInput: {
        disabled: true,
        value: function () {
          var chemical = AutoForm.getFieldValue(this.name.replace('.activeIngredient', '.name'));

          if (!chemical)
            return;

          var data = Fungicides.findOne({name: chemical});

          if (!data)
            return;

          return data.concentration;
        }
      }
    }
  },
  'chemicals.$.dose': {
    type: String,
    optional: true,
    label: 'Dosis'
  },
  'chemicals.$.unit': {
    type: String,
    optional: true,
    label: 'Unidades',
    allowedValues: ['ML/L', 'gr/Ll'],
    autoform: {
      afFieldInput: {
        type: 'select'
      }
    }
  },
  'chemicals.$.ccTotal': {
    type: String,
    optional: true,
    label: 'CC',
    autoform: {
      afFieldInput: {
        disabled: true,
        value: function () {
          var applied = AutoForm.getFieldValue('appliedMixture');
          var remaining = AutoForm.getFieldValue('remainingMixture');
          var dose = AutoForm.getFieldValue(this.name.replace('.ccTotal', '.dose'));
          var unit = AutoForm.getFieldValue(this.name.replace('.ccTotal', '.unit'));
          var chemical = AutoForm.getFieldValue(this.name.replace('.ccTotal', '.name'));

          var total = Number(applied) + Number(remaining);
          var cc = total * Number(dose);

          // $('#ccTotal').parent().find('label').text(unit + ' total de ' + chemical);
          return cc.toFixed(2);
        }
      }
    }
  },
  technicalReason: {
    type: [String],
    optional: true,
    label: 'Razón Técnica',
    allowedValues: ['Evitar pudrición de la corona', 'Prolongar vida verde'],
    autoform: {
      group: 'Step 5',
      afFieldInput: {
        type: 'select-checkbox'
      }
    }
  },
  consultantName: {
    type: String,
    optional: true,
    label: 'Nombre del Asesor',
    autoform: {
      group: 'Step 6'
    }
  },
  applicatorName: {
    type: String,
    optional: true,
    label: 'Nombre del Aplicador',
    autoform: {
      group: 'Step 6'
    }
  },
  packingSupervisor: {
    type: String,
    optional: true,
    label: 'Supervisor de Empacadora',
    autoform: {
      group: 'Step 6'
    }
  },
  signature: {
    type: [String],
    label: 'Signature',
    autoform: {
      group: 'Step 6',
      type: "signature"
    }
  }
});
```
