### PR TITLE
Adds regex support to addHooks

### DIFF
--- a/autoform-api.js
+++ b/autoform-api.js
@@ -21,7 +21,7 @@ AutoForm.Utility = Utility;
  * form.
  */
 AutoForm.addHooks = function autoFormAddHooks(formIds, hooks, replace) {
-  if (typeof formIds === "string") {
+  if (typeof formIds === "string" || formIds instanceof RegExp) {
     formIds = [formIds];
   }
 
@@ -30,11 +30,20 @@ AutoForm.addHooks = function autoFormAddHooks(formIds, hooks, replace) {
     Hooks.addHooksToList(Hooks.global, hooks, replace);
   } else {
     _.each(formIds, function (formId) {
+      if(formId instanceof RegExp) {
+        // Stash regex and let forms check to see if they match as they're created
+        // We do this since we don't know the actual form ID here, and therefor can't add the hooks
+        Hooks.regex[formId] = {
+          regex: formId,
+          hooks: hooks,
+          replace: replace
+        };
+      } else {
+        // Init the hooks object if not done yet
+        Hooks.form[formId] = Hooks.form[formId] || Hooks.getDefault();
 
-      // Init the hooks object if not done yet
-      Hooks.form[formId] = Hooks.form[formId] || Hooks.getDefault();
-
-      Hooks.addHooksToList(Hooks.form[formId], hooks, replace);
+        Hooks.addHooksToList(Hooks.form[formId], hooks, replace);
+      }
     });
   }
 };

--- a/autoform-hooks.js
+++ b/autoform-hooks.js
@@ -1,7 +1,8 @@
 // Manages all hooks, supporting append/replace, get
 
 Hooks = {
-  form: {}
+  form: {},
+  regex: {},
 };
 
 // The names of all supported hooks, excluding "before" and "after".

--- a/components/autoForm/autoForm.js
+++ b/components/autoForm/autoForm.js
@@ -1,5 +1,18 @@
 /* global AutoForm, ReactiveVar, arrayTracker, Hooks, MongoObject, Utility, setDefaults */
 
+Template.autoForm.onCreated(function() {
+  var self = this;
+
+  _.each(Hooks.regex, function(opts, re) {
+    if(opts.regex.test(self.data.id)) {
+      // Init the hooks object if not done yet
+      Hooks.form[self.data.id] = Hooks.form[self.data.id] || Hooks.getDefault();
+
+      Hooks.addHooksToList(Hooks.form[self.data.id], opts.hooks, opts.replace);
+    }
+  });
+});
+
 Template.autoForm.helpers({
   atts: function autoFormTplAtts() {
     // After removing all of the props we know about, everything else should

--- a/components/quickForm/quickForm.js
+++ b/components/quickForm/quickForm.js
@@ -1,5 +1,17 @@
 /* global AutoForm */
 
+Template.quickForm.onCreated(function() {
+  var self = this;
+
+  _.each(Hooks.regex, function(opts, re) {
+    if(opts.regex.test(self.data.id)) {
+      // Init the hooks object if not done yet
+      Hooks.form[self.data.id] = Hooks.form[self.data.id] || Hooks.getDefault();
+      Hooks.addHooksToList(Hooks.form[self.data.id], opts.hooks, opts.replace);
+    }
+  });
+});
+
 Template.quickForm.helpers({
   getTemplateName: function () {
     return AutoForm.getTemplateName('quickForm', this.template);


### PR DESCRIPTION
See issue #745.

This method of supporting regex in `AutoForm.addHooks` relies on adding `onCreated` template hooks to `quickForm` and `autoForm` templates. These hooks are required because the actual ids of the form templates are not known until this point, and therefor the form hook cannot be added util then. These template hooks may have other implications that I'm not aware of so please review and suggest changes.
