### PR TITLE
Bug expand obj

### DIFF
--- a/tests/utility-tests.js
+++ b/tests/utility-tests.js
@@ -226,6 +226,13 @@ if (Meteor.isClient) {
       baz: 1
     });
     testExpandObj({
+      'foo.0bar': "baz",
+      baz: 1
+    }, {
+      foo: {"0bar": "baz"},
+      baz: 1
+    });
+    testExpandObj({
       'foo.bar.0': "foo",
       'foo.bar.1': "baz",
       baz: 1

--- a/utility.js
+++ b/utility.js
@@ -221,7 +221,6 @@ Utility = {
         } else {
           //see if the next piece is a number
           nextPiece = subkeys[i + 1];
-          nextPiece = parseInt(nextPiece, 10);
           if (isNaN(nextPiece) && !_.isObject(current[subkey])) {
             current[subkey] = {};
           } else if (!isNaN(nextPiece) && !_.isArray(current[subkey])) {


### PR DESCRIPTION
expandObj should work with keys that starts with a digit. 
parseInt("1foo") will return an integer, which will make `isNaN(nextPiece)` to return true. 
