### PR TITLE
allows options for passing in the type of select field for array fields

### DIFF
--- a/templates/bootstrap3/components/afArrayField/afArrayField.html
+++ b/templates/bootstrap3/components/afArrayField/afArrayField.html
@@ -7,7 +7,7 @@
     </div>
     {{/if}}
     <ul class="list-group">
-      {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
+      {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount options=this.attrs.options type=this.attr.type}}
       <li class="list-group-item autoform-array-item">
         <div>
           <div class="autoform-remove-item-wrap">
@@ -16,7 +16,7 @@
             {{/if}}
           </div>
           <div class="autoform-array-item-body">
-            {{> afQuickField name=this.name label=false options=afOptionsFromSchema}}
+            {{> afQuickField name=this.name type=../atts.type label=false options=../atts.options}}
           </div>
         </div>
       </li>


### PR DESCRIPTION
I was having the hardest time figuring out how to change the input field type of an afArrayField, and then noticed that you can't.

This allows you to supply the `type` and `options` attributes to an `afArrayField` for better customization.

For example, in my application I have the two afArrayFields:

```
 {{> afArrayField name="domain.websites"}}
 {{> afArrayField name="species" type="select" options=species}}
```

![screen shot 2016-10-13 at 1 24 19 pm](https://cloud.githubusercontent.com/assets/3743882/19359496/6fdda460-9148-11e6-8b37-38c4b153a479.png)
